### PR TITLE
Add locale-aware datetime handling throughout stack

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 Neville Brem
+Copyright 2026 Neville Brem
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import { auth } from '$lib/auth';
+import { resolveUserLocale, resolveUserTimeZone } from '$lib/server/user-preferences';
 import { svelteKitHandler } from 'better-auth/svelte-kit';
 
 export async function handle({ event, resolve }) {
@@ -7,7 +8,10 @@ export async function handle({ event, resolve }) {
 	});
 
 	if (session) {
-		event.locals.user = session.user;
+		const timeZone = resolveUserTimeZone(session.user, event.cookies);
+		const locale = resolveUserLocale(session.user, event.cookies, event.request.headers);
+
+		event.locals.user = { ...session.user, timeZone, locale };
 		event.locals.session = session.session;
 	}
 

--- a/src/lib/components/Event.svelte
+++ b/src/lib/components/Event.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { eventsTable, projectsTable } from '$lib/db/schema';
+	import { dayjs } from '$lib/datetime';
 	import { cn, prettyDate } from '$lib/utils';
 	import type { zToggleEvent, zEditEvent } from '$lib/zod';
-	import dayjs from 'dayjs';
 	import { type SuperValidated, type Infer, superForm, dateProxy } from 'sveltekit-superforms';
 	import Spinner from './Spinner.svelte';
 	import Label from './Label.svelte';
@@ -22,9 +22,11 @@
 			id: number;
 			name: string;
 		}[];
+		locale?: string | null;
+		timeZone?: string | null;
 	}
 
-	let { editFormData, toggleFormData, event, projects }: Props = $props();
+	let { editFormData, toggleFormData, event, projects, locale, timeZone }: Props = $props();
 
 	let editModal: HTMLDialogElement;
 	let toggleModal: HTMLDialogElement;
@@ -55,12 +57,14 @@
 		id: `toggleForm-${event.id}`
 	});
 
-	const date = $derived(dayjs(event.date));
+	const eventDate = $derived(timeZone ? dayjs(event.date).tz(timeZone) : dayjs(event.date));
 	const dateInput = dateProxy(editForm, 'date', { format: 'datetime-local' });
 
 	$editForm.event = event.content;
 	$editForm.id = event.id;
-	$dateInput = dayjs(event.date).format('YYYY-MM-DDTHH:mm:ss.SSS');
+	$dateInput = (timeZone ? dayjs(event.date).tz(timeZone) : dayjs(event.date)).format(
+		'YYYY-MM-DDTHH:mm:ss.SSS'
+	);
 	if (event.projectId) {
 		$editForm.projectId = event.projectId;
 	} else {
@@ -79,9 +83,15 @@
 		</h1>
 		<div class="text-md md:text-base">
 			<p>
-				<span class={cn(date.isBefore(dayjs().startOf('day')) && !event.completed && 'text-error')}>
-					{prettyDate(event.date)}
-				</span>
+					<span
+						class={cn(
+							eventDate.isBefore(
+								timeZone ? dayjs().tz(timeZone).startOf('day') : dayjs().startOf('day')
+							) && !event.completed && 'text-error'
+						)}
+					>
+						{prettyDate(event.date, { locale, timeZone })}
+					</span>
 				{#if event.project}
 					<a href={`/projects/${event.project.id}`} class="text-secondary"
 						><i class="fa-solid fa-arrow-right max-md:hidden"></i>
@@ -134,7 +144,9 @@
 							type="datetime-local"
 							placeholder="When?"
 							class="input input-bordered"
-							defaultValue={dayjs(event.date).format('YYYY-MM-DDTHH:mm:ss.SSS')}
+							defaultValue={(timeZone ? dayjs(event.date).tz(timeZone) : dayjs(event.date)).format(
+								'YYYY-MM-DDTHH:mm:ss.SSS'
+							)}
 						/>
 					</div>
 					<div class="flex flex-col md:col-span-2">

--- a/src/lib/components/EventDemo.svelte
+++ b/src/lib/components/EventDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import dayjs from 'dayjs';
+	import { dayjs } from '$lib/datetime';
 </script>
 
 <div class="flex flex-col items-center justify-center gap-4">

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -1,15 +1,27 @@
 <script lang="ts">
 	import type { users } from '$lib/db/schema';
-	import dayjs from 'dayjs';
+	import { dayjs, formatDate, parseUserDateTime } from '$lib/datetime';
 
 	interface Props {
 		name: string;
-		deadline: string | null;
+		deadline: string | Date | null;
 		collaborators: (typeof users.$inferSelect)[];
 		id: number;
+		locale?: string | null;
+		timeZone?: string | null;
 	}
 
-	let { name, deadline, collaborators, id }: Props = $props();
+	let { name, deadline, collaborators, id, locale, timeZone }: Props = $props();
+
+	const deadlineDate = $derived(() => {
+		if (!deadline) return null;
+		const dateString =
+			deadline instanceof Date ? dayjs(deadline).utc().format('YYYY-MM-DD') : deadline;
+		const parsed = timeZone
+			? parseUserDateTime(`${dateString}T00:00`, timeZone)
+			: new Date(dateString);
+		return Number.isNaN(parsed.getTime()) ? null : parsed;
+	});
 </script>
 
 <a
@@ -29,8 +41,8 @@
 			{/if}
 		</p>
 		<p class="text-muted font-medium">
-			{#if deadline}
-				<span>Deadline: {dayjs(deadline).format('D MMMM YYYY')}</span>
+			{#if deadlineDate}
+				<span>Deadline: {formatDate(deadlineDate, { locale, timeZone })}</span>
 			{:else}
 				<span>No deadline set</span>
 			{/if}

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -13,7 +13,7 @@
 
 	let { name, deadline, collaborators, id, locale, timeZone }: Props = $props();
 
-	const deadlineDate = $derived(() => {
+	const deadlineDate = $derived.by(() => {
 		if (!deadline) return null;
 		const dateString =
 			deadline instanceof Date ? dayjs(deadline).utc().format('YYYY-MM-DD') : deadline;

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -65,12 +65,15 @@ export function parseUserDateTime(value: string, timeZone: string) {
 	const trimmed = value?.trim();
 	if (!trimmed) return new Date(NaN);
 
+	const resolvedTimeZone = safeTimeZone(timeZone);
+	if (!resolvedTimeZone) return new Date(NaN);
+
 	// If the value already includes a zone/offset, respect it.
 	if (/[zZ]$/.test(trimmed) || /[+-]\d{2}:?\d{2}$/.test(trimmed)) {
 		return new Date(trimmed);
 	}
 
-	const zoned = dayjs.tz(trimmed.replace(' ', 'T'), timeZone);
+	const zoned = dayjs.tz(trimmed.replace(' ', 'T'), resolvedTimeZone);
 	return zoned.toDate();
 }
 

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,85 @@
+import dayjsLib from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+const dayjs = dayjsLib;
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(relativeTime);
+
+export { dayjs };
+
+export function normalizeLocale(locale?: string | null) {
+	if (!locale) return undefined;
+	try {
+		return Intl.getCanonicalLocales(locale)[0];
+	} catch {
+		return undefined;
+	}
+}
+
+export function safeTimeZone(timeZone?: string | null) {
+	if (!timeZone) return undefined;
+	try {
+		return Intl.DateTimeFormat('en-US', { timeZone }).resolvedOptions().timeZone;
+	} catch {
+		return undefined;
+	}
+}
+
+export function formatDateTime(
+	date: Date,
+	options?: {
+		locale?: string | null;
+		timeZone?: string | null;
+		dateStyle?: Intl.DateTimeFormatOptions['dateStyle'];
+		timeStyle?: Intl.DateTimeFormatOptions['timeStyle'];
+	}
+) {
+	const locale = normalizeLocale(options?.locale) ?? undefined;
+	const timeZone = safeTimeZone(options?.timeZone) ?? undefined;
+	const dateStyle = options?.dateStyle ?? 'long';
+	const timeStyle = options?.timeStyle ?? 'short';
+
+	return new Intl.DateTimeFormat(locale, { dateStyle, timeStyle, timeZone }).format(date);
+}
+
+export function formatDate(
+	date: Date,
+	options?: {
+		locale?: string | null;
+		timeZone?: string | null;
+		dateStyle?: Intl.DateTimeFormatOptions['dateStyle'];
+	}
+) {
+	const locale = normalizeLocale(options?.locale) ?? undefined;
+	const timeZone = safeTimeZone(options?.timeZone) ?? undefined;
+	const dateStyle = options?.dateStyle ?? 'long';
+
+	return new Intl.DateTimeFormat(locale, { dateStyle, timeZone }).format(date);
+}
+
+export function parseUserDateTime(value: string, timeZone: string) {
+	const trimmed = value?.trim();
+	if (!trimmed) return new Date(NaN);
+
+	// If the value already includes a zone/offset, respect it.
+	if (/[zZ]$/.test(trimmed) || /[+-]\d{2}:?\d{2}$/.test(trimmed)) {
+		return new Date(trimmed);
+	}
+
+	const zoned = dayjs.tz(trimmed.replace(' ', 'T'), timeZone);
+	return zoned.toDate();
+}
+
+export function formatDateTimeIso(date: Date, timeZone: string) {
+	return dayjs(date).tz(timeZone).format();
+}
+
+export function normalizeDateInput(value: string) {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+	return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : undefined;
+}

--- a/src/lib/db/schema/auth.sql.ts
+++ b/src/lib/db/schema/auth.sql.ts
@@ -11,6 +11,8 @@ export const users = pgTable(
 		createdAt: timestamp('created_at').notNull(),
 		updatedAt: timestamp('updated_at').notNull(),
 		stripeCustomerId: text('stripe_customer_id'),
+		locale: text('locale'),
+		timeZone: text('time_zone'),
 		role: text('role'),
 		banned: boolean('banned'),
 		banReason: text('ban_reason'),

--- a/src/lib/server/user-preferences.ts
+++ b/src/lib/server/user-preferences.ts
@@ -1,0 +1,24 @@
+import type { Cookies } from '@sveltejs/kit';
+import type { User } from '$lib/auth';
+import { normalizeLocale, safeTimeZone } from '$lib/datetime';
+
+export function resolveUserTimeZone(user: User | null, cookies: Cookies) {
+	const userTimeZone = safeTimeZone(user?.timeZone);
+	if (userTimeZone) return userTimeZone;
+
+	const cookieTimeZone = safeTimeZone(cookies.get('tz'));
+	if (cookieTimeZone) return cookieTimeZone;
+
+	return 'UTC';
+}
+
+export function resolveUserLocale(user: User | null, cookies: Cookies, headers: Headers) {
+	const userLocale = normalizeLocale(user?.locale);
+	if (userLocale) return userLocale;
+
+	const cookieLocale = normalizeLocale(cookies.get('locale'));
+	if (cookieLocale) return cookieLocale;
+
+	const headerLocale = normalizeLocale(headers.get('accept-language')?.split(',')[0]);
+	return headerLocale ?? 'en-US';
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,10 @@
 import { redirect } from '@sveltejs/kit';
 import clsx, { type ClassValue } from 'clsx';
 import { superValidate } from 'sveltekit-superforms';
-import { zod, zod4 } from 'sveltekit-superforms/adapters';
+import { zod4 } from 'sveltekit-superforms/adapters';
 import { twMerge } from 'tailwind-merge';
 import { zEditEvent, zToggleEvent } from './zod';
+import { formatDateTime } from './datetime';
 
 export function checkUser(locals: App.Locals) {
 	const user = locals.user;
@@ -22,6 +23,9 @@ export async function initializeEventForms() {
 	return { editForm, toggleForm };
 }
 
-export function prettyDate(date: Date) {
-	return Intl.DateTimeFormat('en', { dateStyle: 'long', timeStyle: 'short' }).format(date);
+export function prettyDate(
+	date: Date,
+	options?: { locale?: string | null; timeZone?: string | null }
+) {
+	return formatDateTime(date, options);
 }

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -5,7 +5,7 @@ export const zEventLLM = z.object({
 	date: z.iso
 		.datetime({ offset: true, local: true })
 		.describe(
-			'The due date and time of the event or task. It should always be in the future and make sense in regard of the content and human behavior. The time should not be too specific. Provide in ISO format.'
+			'The due date and time of the event or task. It should always be in the future and make sense in regard of the content and human behavior. The time should not be too specific. Provide in ISO 8601, preferably with a timezone offset for the user.'
 		),
 	content: z
 		.string()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,31 @@
 <script>
 	import { dev } from '$app/environment';
+	import { onMount } from 'svelte';
 	import logo from '$lib/assets/zenith-logo.svg';
 	import '../app.css';
 
 	const { children, data } = $props();
 
 	const user = data.user;
+
+	onMount(async () => {
+		if (!user) return;
+
+		const resolved = Intl.DateTimeFormat().resolvedOptions();
+		const locale = resolved.locale ?? navigator.language;
+		const timeZone = resolved.timeZone;
+
+		if (!locale || !timeZone) return;
+		if (user.locale === locale && user.timeZone === timeZone) return;
+
+		await fetch('/api/user-context', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json'
+			},
+			body: JSON.stringify({ locale, timeZone })
+		});
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -6,7 +6,7 @@ import type { Actions, PageServerLoad } from './$types';
 import { superValidate, fail, setError } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { redirect } from '@sveltejs/kit';
-import dayjs from 'dayjs';
+import { dayjs, formatDateTimeIso, parseUserDateTime } from '$lib/datetime';
 import { db } from '$lib/db';
 import { eventsTable, freeTierGenerations } from '$lib/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -14,15 +14,17 @@ import { checkUser, initializeEventForms, prettyDate } from '$lib/utils';
 import { dev } from '$app/environment';
 import { getActiveSubscription } from '$lib/auth';
 import { Ratelimit } from '@unkey/ratelimit';
+import { resolveUserLocale, resolveUserTimeZone } from '$lib/server/user-preferences';
 
-export const load: PageServerLoad = async ({ locals, request }) => {
+export const load: PageServerLoad = async ({ locals, request, cookies }) => {
 	const user = checkUser(locals);
+	const timeZone = resolveUserTimeZone(user, cookies);
 
 	const events = db.query.eventsTable.findMany({
 		orderBy: { date: 'asc' },
 		where: {
 			date: {
-				lt: dayjs().endOf('day').toDate()
+				lt: dayjs().tz(timeZone).endOf('day').toDate()
 			},
 			userId: user.id,
 			completed: false
@@ -39,7 +41,7 @@ export const load: PageServerLoad = async ({ locals, request }) => {
 	});
 
 	const freeTodayCount = freeToday.filter((e) =>
-		dayjs(e.createdAt).isSame(new Date(), 'day')
+		dayjs(e.createdAt).tz(timeZone).isSame(dayjs().tz(timeZone), 'day')
 	).length;
 
 	const createForm = await superValidate(zod4(zCreateEvent));
@@ -58,12 +60,23 @@ export const load: PageServerLoad = async ({ locals, request }) => {
 		}
 	});
 
-	return { createForm, events, editForm, user, toggleForm, projects, subscription, freeTodayCount };
+	return {
+		createForm,
+		events,
+		editForm,
+		user,
+		toggleForm,
+		projects,
+		subscription,
+		freeTodayCount
+	};
 };
 
 export const actions = {
-	create: async ({ request, locals }) => {
+	create: async ({ request, locals, cookies }) => {
 		const user = checkUser(locals);
+		const timeZone = resolveUserTimeZone(user, cookies);
+		const locale = resolveUserLocale(user, cookies, request.headers);
 
 		const subscription = await getActiveSubscription(request.headers);
 		const freeToday = await db.query.freeTierGenerations.findMany({
@@ -72,7 +85,9 @@ export const actions = {
 			}
 		});
 
-		const freeTodayCount = freeToday.filter((e) => dayjs(e.createdAt).isSame('day')).length;
+		const freeTodayCount = freeToday.filter((e) =>
+			dayjs(e.createdAt).tz(timeZone).isSame(dayjs().tz(timeZone), 'day')
+		).length;
 
 		if (!subscription && freeTodayCount >= 5) return redirect(302, '/account/billing');
 
@@ -92,7 +107,7 @@ export const actions = {
 
 			const { success, reset } = await limiter.limit(user.id);
 
-			const resetTime = prettyDate(dayjs(reset).toDate());
+			const resetTime = prettyDate(dayjs(reset).toDate(), { locale, timeZone });
 
 			if (!success && user.role != 'admin') {
 				return setError(form, `Reached a limit. Try again at ${resetTime}`, { status: 429 });
@@ -105,6 +120,12 @@ export const actions = {
 			}
 		});
 
+		const nowInUserTimeZone = dayjs().tz(timeZone);
+		const usersEventsForPrompt = usersEvents.map((event) => ({
+			content: event.content,
+			date: formatDateTimeIso(event.date, timeZone)
+		}));
+
 		const { object, finishReason } = await generateObject({
 			model: createGateway({
 				apiKey: VERCEL_GW_KEY
@@ -113,14 +134,21 @@ export const actions = {
 			schemaName: 'Event',
 			schemaDescription: 'An event or a task',
 			system:
-				`Right now is ${new Date()}.` +
+				`Right now is ${nowInUserTimeZone.format()} (${timeZone}, locale ${locale}). ` +
 				`You are an assistant who processes the users input to an event for a todo-like app.` +
-				`Please pay attention to the other events: ${usersEvents}`,
+				`Please pay attention to the other events (times are in the user's time zone): ${JSON.stringify(
+					usersEventsForPrompt
+				)}`,
 			prompt: form.data.event,
 			maxRetries: 5
 		});
 
 		if (finishReason == 'error') return setError(form, 'Generation error');
+
+		const parsedDate = parseUserDateTime(object.date, timeZone);
+		if (Number.isNaN(parsedDate.getTime())) {
+			return setError(form, 'Could not parse a valid date from the generated event.');
+		}
 
 		if (!subscription) {
 			await db.insert(freeTierGenerations).values({
@@ -130,14 +158,18 @@ export const actions = {
 
 		await db.insert(eventsTable).values({
 			content: object.content,
-			date: new Date(object.date),
+			date: parsedDate,
 			userId: user.id
 		});
 
 		return { form };
 	},
-	edit: async ({ request, locals }) => {
+	edit: async ({ request, locals, cookies }) => {
 		const user = checkUser(locals);
+		const timeZone = resolveUserTimeZone(user, cookies);
+
+		const formData = await request.clone().formData();
+		const rawDate = formData.get('date');
 
 		const form = await superValidate(request, zod4(zEditEvent));
 
@@ -177,7 +209,13 @@ export const actions = {
 			.update(eventsTable)
 			.set({
 				content: form.data.event,
-				date: dayjs(form.data.date).toDate(),
+				date: (() => {
+					if (typeof rawDate === 'string') {
+						const parsed = parseUserDateTime(rawDate, timeZone);
+						return Number.isNaN(parsed.getTime()) ? dayjs(form.data.date).toDate() : parsed;
+					}
+					return dayjs(form.data.date).toDate();
+				})(),
 				projectId: projectId
 			})
 			.where(eq(eventsTable.id, form.data.id));

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -205,17 +205,19 @@ export const actions = {
 			}
 		}
 
+		const parsedDate = parseUserDateTime(
+			typeof rawDate === 'string' ? rawDate : String(rawDate ?? ''),
+			timeZone
+		);
+		if (Number.isNaN(parsedDate.getTime())) {
+			return setError(form, 'Invalid date provided', { status: 400 });
+		}
+
 		await db
 			.update(eventsTable)
 			.set({
 				content: form.data.event,
-				date: (() => {
-					if (typeof rawDate === 'string') {
-						const parsed = parseUserDateTime(rawDate, timeZone);
-						return Number.isNaN(parsed.getTime()) ? dayjs(form.data.date).toDate() : parsed;
-					}
-					return dayjs(form.data.date).toDate();
-				})(),
+				date: parsedDate,
 				projectId: projectId
 			})
 			.where(eq(eventsTable.id, form.data.id));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,8 +4,7 @@
 	import Error from '$lib/components/Error.svelte';
 	import Loading from '$lib/components/Loading.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
-	import dayjs from 'dayjs';
-	import relativeTime from 'dayjs/plugin/relativeTime';
+	import { dayjs } from '$lib/datetime';
 	import { cn } from '$lib/utils.js';
 
 	let { data } = $props();
@@ -16,7 +15,8 @@
 		invalidateAll: true
 	});
 
-	dayjs.extend(relativeTime);
+	const userLocale = $derived(data.user?.locale);
+	const userTimeZone = $derived(data.user?.timeZone);
 </script>
 
 <svelte:head>
@@ -77,8 +77,13 @@
 			{#if events.length == 0}
 				<h2 class="heading-small italic">All done for today!</h2>
 			{:else}
-				{@const dueEvents = events.filter((e) => dayjs(e.date).isAfter(dayjs()))}
-				{@const overDueEvents = events.filter((e) => dayjs(e.date).isBefore(dayjs()))}
+				{@const now = userTimeZone ? dayjs().tz(userTimeZone) : dayjs()}
+				{@const dueEvents = events.filter((e) =>
+					(userTimeZone ? dayjs(e.date).tz(userTimeZone) : dayjs(e.date)).isAfter(now)
+				)}
+				{@const overDueEvents = events.filter((e) =>
+					(userTimeZone ? dayjs(e.date).tz(userTimeZone) : dayjs(e.date)).isBefore(now)
+				)}
 				{#if dueEvents.length != 0}
 					<h3 class="heading-sub my-4 mr-auto">Today:</h3>
 					<div class="flex w-full flex-col gap-4">
@@ -88,6 +93,8 @@
 								{event}
 								editFormData={data.editForm}
 								toggleFormData={data.toggleForm}
+								locale={userLocale}
+								timeZone={userTimeZone}
 							/>
 						{/each}
 					</div>
@@ -101,6 +108,8 @@
 								{event}
 								editFormData={data.editForm}
 								toggleFormData={data.toggleForm}
+								locale={userLocale}
+								timeZone={userTimeZone}
 							/>
 						{/each}
 					</div>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -1,13 +1,15 @@
-<script lang="ts">
-	import { cn } from '$lib/utils.js';
-	import dayjs from 'dayjs';
-	import relativeTime from 'dayjs/plugin/relativeTime';
-
-	dayjs.extend(relativeTime);
+	<script lang="ts">
+		import { cn } from '$lib/utils.js';
+		import { dayjs } from '$lib/datetime';
 
 	let { data } = $props();
 
 	const user = data.user;
+	const userTimeZone = $derived(data.user?.timeZone);
+	const now = $derived(userTimeZone ? dayjs().tz(userTimeZone) : dayjs());
+	const joinedAt = $derived(
+		userTimeZone ? dayjs(user.createdAt).tz(userTimeZone) : dayjs(user.createdAt)
+	);
 
 	let revealed = $state(false);
 </script>
@@ -42,7 +44,7 @@
 		</li>
 		<li>
 			<span class="font-medium">Joined:</span>
-			<span class="text-muted">{dayjs().to(dayjs(user.createdAt))}</span>
+			<span class="text-muted">{now.to(joinedAt)}</span>
 		</li>
 		<li>
 			<span class="font-medium">Paid:</span>

--- a/src/routes/account/edit/+page.server.ts
+++ b/src/routes/account/edit/+page.server.ts
@@ -1,7 +1,7 @@
 import type { Actions, PageServerLoad } from './$types';
 import { checkUser } from '$lib/utils';
 import { superValidate, fail, setError } from 'sveltekit-superforms';
-import { zod, zod4 } from 'sveltekit-superforms/adapters';
+import { zod4 } from 'sveltekit-superforms/adapters';
 import { zUpdateUser } from '$lib/zod';
 import { users } from '$lib/db/schema';
 import { db } from '$lib/db';

--- a/src/routes/api/user-context/+server.ts
+++ b/src/routes/api/user-context/+server.ts
@@ -1,0 +1,53 @@
+import { db } from '$lib/db';
+import { users } from '$lib/db/schema';
+import { normalizeLocale, safeTimeZone } from '$lib/datetime';
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+
+export const POST: RequestHandler = async ({ request, locals, cookies }) => {
+	const user = locals.user;
+	if (!user) {
+		return json({ ok: false }, { status: 401 });
+	}
+
+	let body: { locale?: string; timeZone?: string } | null = null;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ ok: false }, { status: 400 });
+	}
+
+	const locale = normalizeLocale(body?.locale);
+	const timeZone = safeTimeZone(body?.timeZone);
+
+	if (!locale && !timeZone) {
+		return json({ ok: true });
+	}
+
+	await db
+		.update(users)
+		.set({
+			locale: locale ?? user.locale ?? null,
+			timeZone: timeZone ?? user.timeZone ?? null,
+			updatedAt: new Date()
+		})
+		.where(eq(users.id, user.id));
+
+	if (timeZone) {
+		cookies.set('tz', timeZone, {
+			path: '/',
+			sameSite: 'lax',
+			maxAge: 60 * 60 * 24 * 365
+		});
+	}
+
+	if (locale) {
+		cookies.set('locale', locale, {
+			path: '/',
+			sameSite: 'lax',
+			maxAge: 60 * 60 * 24 * 365
+		});
+	}
+
+	return json({ ok: true });
+};

--- a/src/routes/completed/+page.svelte
+++ b/src/routes/completed/+page.svelte
@@ -4,6 +4,8 @@
 	import Loading from '$lib/components/Loading.svelte';
 
 	let { data } = $props();
+	const userLocale = $derived(data.user?.locale);
+	const userTimeZone = $derived(data.user?.timeZone);
 </script>
 
 <svelte:head>
@@ -25,6 +27,8 @@
 						{event}
 						editFormData={data.editForm}
 						toggleFormData={data.toggleForm}
+						locale={userLocale}
+						timeZone={userTimeZone}
 					/>
 				{/each}
 			{/if}

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -4,6 +4,8 @@
 	import Error from '../+error.svelte';
 
 	let { data } = $props();
+	const userLocale = $derived(data.user?.locale);
+	const userTimeZone = $derived(data.user?.timeZone);
 </script>
 
 <svelte:head>
@@ -38,6 +40,8 @@
 						collaborators={project.collaborators}
 						name={project.name}
 						deadline={project.deadline}
+						locale={userLocale}
+						timeZone={userTimeZone}
 					/>
 				{/each}
 			{/if}

--- a/src/routes/projects/[projectId]/+page.server.ts
+++ b/src/routes/projects/[projectId]/+page.server.ts
@@ -6,11 +6,13 @@ import { projectsTable } from '$lib/db/schema';
 import { error, redirect } from '@sveltejs/kit';
 import { fail, setMessage, superValidate } from 'sveltekit-superforms';
 import { zDeleteProject, zEditProject } from '$lib/zod';
-import { zod, zod4 } from 'sveltekit-superforms/adapters';
-import dayjs from 'dayjs';
+import { zod4 } from 'sveltekit-superforms/adapters';
+import { dayjs, normalizeDateInput } from '$lib/datetime';
+import { resolveUserTimeZone } from '$lib/server/user-preferences';
 
-export const load: PageServerLoad = async ({ params, locals }) => {
+export const load: PageServerLoad = async ({ params, locals, cookies }) => {
 	const user = checkUser(locals);
+	const timeZone = resolveUserTimeZone(user, cookies);
 
 	const projectId = Number(params.projectId);
 
@@ -46,10 +48,15 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 	const { editForm, toggleForm } = await initializeEventForms();
 
+	const deadlineString =
+		project.deadline instanceof Date
+			? dayjs(project.deadline).utc().format('YYYY-MM-DD')
+			: project.deadline;
+
 	const projectEditForm = await superValidate(zod4(zEditProject), {
 		defaults: {
 			projectId: project.id,
-			deadline: dayjs(project.deadline).isValid() ? dayjs(project.deadline).toDate() : undefined,
+			deadline: deadlineString ? dayjs.tz(deadlineString, timeZone).toDate() : undefined,
 			name: project.name
 		}
 	});
@@ -72,6 +79,10 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 export const actions = {
 	edit: async ({ locals, request }) => {
 		const user = checkUser(locals);
+		const formData = await request.clone().formData();
+		const rawDeadline = formData.get('deadline');
+		const deadline = typeof rawDeadline === 'string' ? normalizeDateInput(rawDeadline) : undefined;
+
 		const form = await superValidate(request, zod4(zEditProject));
 
 		if (!form.valid) return fail(400, { form });
@@ -82,20 +93,20 @@ export const actions = {
 
 		if (!qProject) return fail(429, { form });
 
-		if (form.data.deadline && form.data.name) {
+		if (deadline && form.data.name) {
 			await db
 				.update(projectsTable)
 				.set({
-					deadline: form.data.deadline.toDateString(),
+					deadline: deadline,
 					name: form.data.name
 				})
 				.where(eq(projectsTable.id, form.data.projectId));
 			return setMessage(form, 'Updated deadline and name');
-		} else if (form.data.deadline) {
+		} else if (deadline) {
 			await db
 				.update(projectsTable)
 				.set({
-					deadline: form.data.deadline.toDateString()
+					deadline: deadline
 				})
 				.where(eq(projectsTable.id, form.data.projectId));
 			return setMessage(form, 'Updated deadline');

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -3,13 +3,23 @@
 	import Label from '$lib/components/Label.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { cn } from '$lib/utils.js';
-	import dayjs from 'dayjs';
-	import relativeTime from 'dayjs/plugin/relativeTime.js';
+	import { dayjs, formatDate } from '$lib/datetime';
 	import { dateProxy, superForm } from 'sveltekit-superforms';
 
-	dayjs.extend(relativeTime);
-
 	let { data } = $props();
+	const userLocale = $derived(data.user?.locale);
+	const userTimeZone = $derived(data.user?.timeZone);
+	const deadlineDate = $derived(() => {
+		if (!data.project.deadline) return null;
+		const dateString =
+			data.project.deadline instanceof Date
+				? dayjs(data.project.deadline).utc().format('YYYY-MM-DD')
+				: data.project.deadline;
+		const parsed = userTimeZone
+			? dayjs.tz(`${dateString}T00:00`, userTimeZone)
+			: dayjs(dateString);
+		return parsed.isValid() ? parsed : null;
+	});
 
 	let editModal: HTMLDialogElement;
 
@@ -59,10 +69,13 @@
 					<li>
 						<span class="font-medium">Deadline:</span>
 						<span class="text-muted"
-							>{#if data.project.deadline}
-								{dayjs().to(dayjs(data.project.deadline))} ({dayjs(data.project.deadline).format(
-									'D MMMM YYYY'
-								)})
+							>{#if deadlineDate}
+								{(userTimeZone ? dayjs().tz(userTimeZone) : dayjs()).to(deadlineDate)} (
+								{formatDate(deadlineDate.toDate(), {
+									locale: userLocale,
+									timeZone: userTimeZone
+								})}
+								)
 							{:else}
 								No deadline
 							{/if}
@@ -98,6 +111,8 @@
 							projects={data.userProjects}
 							editFormData={data.editForm}
 							toggleFormData={data.toggleForm}
+							locale={userLocale}
+							timeZone={userTimeZone}
 						/>
 					{/each}
 				</section>
@@ -113,6 +128,8 @@
 							projects={data.userProjects}
 							editFormData={data.editForm}
 							toggleFormData={data.toggleForm}
+							locale={userLocale}
+							timeZone={userTimeZone}
 						/>
 					{/each}
 				</section>

--- a/src/routes/projects/create/+page.server.ts
+++ b/src/routes/projects/create/+page.server.ts
@@ -3,9 +3,10 @@ import type { Actions, PageServerLoad } from './$types';
 import { projectsTable } from '$lib/db/schema';
 import { checkUser } from '$lib/utils';
 import { fail, superValidate } from 'sveltekit-superforms';
-import { zod, zod4 } from 'sveltekit-superforms/adapters';
+import { zod4 } from 'sveltekit-superforms/adapters';
 import { zCreateProject } from '$lib/zod';
 import { redirect } from '@sveltejs/kit';
+import { normalizeDateInput } from '$lib/datetime';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	checkUser(locals);
@@ -19,6 +20,10 @@ export const actions = {
 	default: async ({ locals, request }) => {
 		const user = checkUser(locals);
 
+		const formData = await request.clone().formData();
+		const rawDeadline = formData.get('deadline');
+		const deadline = typeof rawDeadline === 'string' ? normalizeDateInput(rawDeadline) : undefined;
+
 		const form = await superValidate(request, zod4(zCreateProject));
 
 		if (!form.valid) {
@@ -29,7 +34,7 @@ export const actions = {
 			.values({
 				name: form.data.name,
 				userId: user.id,
-				deadline: form.data.deadline?.toDateString()
+				deadline: deadline
 			})
 			.returning({
 				projectId: projectsTable.id

--- a/src/routes/upcoming/+page.server.ts
+++ b/src/routes/upcoming/+page.server.ts
@@ -1,15 +1,17 @@
 import { db } from '$lib/db';
 import type { PageServerLoad } from './$types';
-import dayjs from 'dayjs';
+import { dayjs } from '$lib/datetime';
 import { checkUser, initializeEventForms } from '$lib/utils';
+import { resolveUserTimeZone } from '$lib/server/user-preferences';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, cookies }) => {
 	const user = checkUser(locals);
+	const timeZone = resolveUserTimeZone(user, cookies);
 
 	const events = db.query.eventsTable.findMany({
 		where: {
 			date: {
-				gt: dayjs().endOf('day').toDate()
+				gt: dayjs().tz(timeZone).endOf('day').toDate()
 			},
 			userId: user.id,
 			completed: false

--- a/src/routes/upcoming/+page.svelte
+++ b/src/routes/upcoming/+page.svelte
@@ -4,6 +4,8 @@
 	import Loading from '$lib/components/Loading.svelte';
 
 	let { data } = $props();
+	const userLocale = $derived(data.user?.locale);
+	const userTimeZone = $derived(data.user?.timeZone);
 </script>
 
 <svelte:head>
@@ -25,6 +27,8 @@
 						{event}
 						editFormData={data.editForm}
 						toggleFormData={data.toggleForm}
+						locale={userLocale}
+						timeZone={userTimeZone}
 					/>
 				{/each}
 			{/if}


### PR DESCRIPTION
Summary
- new helpers (`src/lib/datetime.ts`, `src/lib/server/user-preferences.ts`) normalize locales/timezones from auth, headers, and cookies
- timestamps now respect the resolved user locale/timezone on the server (load/actions/hooks) and frontend components (Event, ProjectCard, page views) including AI object generation prompts
- added persistence for user context via `POST /api/user-context` and wired deadline/event inputs to parse/format per user preferences

Testing
- Not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements comprehensive locale-aware datetime handling across the entire stack. Key changes include:

- New helper modules (`datetime.ts`, `user-preferences.ts`) that normalize and resolve user locale/timezone from multiple sources (user profile, cookies, headers)
- Server hooks now enrich the user object with resolved locale/timezone preferences
- All server-side load functions and actions now use timezone-aware date operations for filtering events, parsing user input, and generating AI prompts
- Frontend components (`Event`, `ProjectCard`) accept locale/timezone props and format dates accordingly
- Client-side auto-detection and persistence via new `/api/user-context` endpoint
- Database schema updated to store user `locale` and `timeZone` preferences

The implementation follows a clear priority chain: user database preferences → cookies → browser headers/defaults.

<h3>Confidence Score: 3/5</h3>

- Critical syntax error in ProjectCard will cause runtime failures; datetime parsing lacks validation
- Score of 3 reflects one critical syntax error (`$derived` usage in ProjectCard.svelte) that will break project pages, and missing timezone validation in `parseUserDateTime` that could cause silent failures. The rest of the implementation is solid and well-structured.
- Pay close attention to `src/lib/components/ProjectCard.svelte` (syntax error) and `src/lib/datetime.ts` (missing validation)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/datetime.ts | Added timezone/locale utilities and parsing functions, but `parseUserDateTime` lacks timezone validation |
| src/lib/server/user-preferences.ts | Clean helper functions for resolving user timezone and locale from multiple sources |
| src/hooks.server.ts | Enriches user object with resolved locale and timezone in server hooks |
| src/routes/+page.server.ts | Integrates timezone-aware date handling throughout load function and actions; includes proper validation |
| src/routes/projects/[projectId]/+page.server.ts | Timezone-aware deadline handling in load and edit actions with proper date normalization |
| src/lib/components/ProjectCard.svelte | Added timezone-aware deadline parsing/formatting but has critical `$derived` syntax error |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Layout as +layout.svelte
    participant Hook as hooks.server
    participant UserPref as user-preferences
    participant API as /api/user-context
    participant Server as Page Server
    participant DateTime as datetime.ts
    participant DB as Database

    Browser->>Layout: onMount (detect locale/tz)
    Layout->>Layout: Get Intl.DateTimeFormat().resolvedOptions()
    alt User preferences differ
        Layout->>API: POST /api/user-context {locale, timeZone}
        API->>DateTime: normalizeLocale(locale)
        API->>DateTime: safeTimeZone(timeZone)
        API->>DB: Update user locale/timeZone
        API->>API: Set cookies (tz, locale)
        API-->>Layout: {ok: true}
    end

    Browser->>Server: Request page (with cookies)
    Server->>Hook: handle({event, resolve})
    Hook->>Hook: auth.api.getSession()
    Hook->>UserPref: resolveUserTimeZone(user, cookies)
    Hook->>UserPref: resolveUserLocale(user, cookies, headers)
    Note over UserPref: Priority: user.locale/tz → cookie → header/UTC
    Hook->>Hook: Enrich event.locals.user with resolved values
    Hook-->>Server: Continue with enriched user

    Server->>UserPref: resolveUserTimeZone(user, cookies)
    Server->>UserPref: resolveUserLocale(user, cookies, headers)
    Server->>DateTime: dayjs().tz(timeZone)
    Server->>DB: Query events filtered by user timezone
    Server->>DateTime: formatDateTimeIso(date, timeZone)
    Note over Server: Generate AI prompt with timezone context
    Server->>DateTime: parseUserDateTime(llmDate, timeZone)
    Server->>DB: Insert/Update with parsed date
    Server-->>Browser: Return data with user locale/tz

    Browser->>Browser: Render components with locale/timeZone props
    Note over Browser: Event.svelte, ProjectCard.svelte use<br/>formatDate/formatDateTime with user prefs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->